### PR TITLE
_(:3」∠)_ bash上でエラーが出たので修正

### DIFF
--- a/bin/red
+++ b/bin/red
@@ -6,11 +6,11 @@ CURRENT_DIR=$(basename $(pwd))
 NAME=$(echo $CURRENT_DIR | sed -E "s/[0-9]*$//")
 NUM=$(echo $CURRENT_DIR | sed -E "s/^[^0-9]*//")
 
-NUM=$(printf %0${#NUM}d $(($NUM + JUMP_N)))
+NUM=$(printf %0${#NUM}d $(expr $NUM + $JUMP_N))
 
 if [[ -d ../$NAME$NUM ]]; then
   cd ../$NAME$NUM
 else
   [[ $JUMP_N -eq -1 ]] && JUMP_N=
-  echo "You cannot use \"cd- $JUMP_N\" because $NAME$NUM does not exist"
+  echo "You cannot use \"red $JUMP_N\" because $NAME$NUM does not exist"
 fi


### PR DESCRIPTION
【問題】
  $((a + b))の形では0パディングされた数値を計算できない
【対策】
　1. exprコマンドを使って評価をさせる
　2. 0パディングされた変数を$((10#a + b))とすることで、10進数として認識させる
  今回は1を利用してエラーに対応した