### PR TITLE
_(:3」∠)_ rollで.コマンドを使うことで生じるバグを修正

### DIFF
--- a/bin/roll
+++ b/bin/roll
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-. red
+. red -1
 mkabc $1


### PR DESCRIPTION
.コマンドはカレントシェルでコマンドを実行してしまい、
親コマンドの引数もそのまま引きついでしまうためバグが生まれていた