### PR TITLE
_(:3」∠)_ readlinkによるバグを修正

### DIFF
--- a/bin/symlink
+++ b/bin/symlink
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly DOTDIR=$(readlink -f $0 | sed -e 's/\(.*dotfiles\).*/\1/')
+readonly DOTDIR=$(realpath $0 | sed -e 's/\(.*dotfiles\).*/\1/')
 cd $DOTDIR
 
 usage() {

--- a/etc/setup/initialize.sh
+++ b/etc/setup/initialize.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-DOTDIR=$(readlink -f $0 | sed -e 's/\(.*dotfiles\).*/\1/')
+readonly DOTDIR=$(realpath $0 | sed -e 's/\(.*dotfiles\).*/\1/')
 BIN_DIR=$DOTDIR/bin
 SCRIPT_DIR=$DOTDIR/etc/scripts
 cd $SCRIPT_DIR


### PR DESCRIPTION
readlinkではエラーが起き、symlinkコマンドがうまく動かない
対策としてrealpathコマンドで代用した